### PR TITLE
Fix send to closed channel.

### DIFF
--- a/fcgi.go
+++ b/fcgi.go
@@ -209,6 +209,11 @@ func writeStdin(c net.Conn, w *buffer, id uint16, r io.Reader) error {
 		}
 	}
 
+	// If our body is empty, we probably don't need to send
+	// record at all.
+	if w.Len() == 0 {
+		return nil
+	}
 	return w.WriteRecord(c, id, typeStdin)
 }
 


### PR DESCRIPTION
Sometimes, the code will try to write stdin even after the conn has been closed and thus result in err and attempt to this err to already closed channel. This bug research had lead us to the point where we attempt to send the empty frame into closed conn. Added check for frame len so we wouldn't send the empty one.